### PR TITLE
bountiful ergo bounty platform

### DIFF
--- a/contracts/proposal_v1_1.es
+++ b/contracts/proposal_v1_1.es
@@ -1,8 +1,8 @@
 {
   // ===== Proposal Contract Description ===== //
   // Name: Bountiful Proposal Contract 
-  // Description: Allows bounty creators to approve proposals and transfer rewards
-  // Version: 1.3.0 - Fixed signature/boolean separation
+  // Description: Adds a Judge System phase for resolving disputes
+  // Version: 1.4.0
   // Author: Bountiful Team
 
   val proposerPK = SELF.R4[GroupElement].get
@@ -15,12 +15,12 @@
   val isApproved = status == 1
   val isRejected = status == 2
   val isDisputed = status == 3
+  val isJudgeSystem = status == 4
 
   // Helper function to check if a box proposition matches a SigmaProp
   def isSigmaPropEqualToBoxProp(propAndBox: (SigmaProp, Box)): Boolean = {
     val prop: SigmaProp = propAndBox._1
     val box: Box = propAndBox._2
-
     val propBytes: Coll[Byte] = prop.propBytes
     val treeBytes: Coll[Byte] = box.propositionBytes
 
@@ -32,6 +32,7 @@
     }
   }
 
+  // Dispute can be triggered by either the proposer or the bounty creator
   val isDisputeAction = {
     allOf(Coll(
       (isPending || isApproved || isRejected),
@@ -41,7 +42,23 @@
       OUTPUTS(0).R7[SigmaProp].get == bountyCreatorProp,
       OUTPUTS(0).value == SELF.value,
       OUTPUTS(0).propositionBytes == SELF.propositionBytes,
-      OUTPUTS(0).R8[Int].get == 3
+      OUTPUTS(0).R8[Int].get == 3,
+      anyOf(Coll(bountyCreatorProp, proveDlog(proposerPK)))
+    ))
+  }
+
+  // Escalate an existing dispute into the Judge System phase (creator-only)
+  val isEscalateToJudgeSystemAction = {
+    allOf(Coll(
+      isDisputed,
+      OUTPUTS(0).R4[GroupElement].get == proposerPK,
+      OUTPUTS(0).R5[Coll[Byte]].get == bountyId,
+      OUTPUTS(0).R6[Coll[Byte]].get == metadataJson,
+      OUTPUTS(0).R7[SigmaProp].get == bountyCreatorProp,
+      OUTPUTS(0).value == SELF.value,
+      OUTPUTS(0).propositionBytes == SELF.propositionBytes,
+      OUTPUTS(0).R8[Int].get == 4,
+      bountyCreatorProp
     ))
   }
 
@@ -57,9 +74,25 @@
     ))
   }
 
+  // Creator can explicitly reject a proposal from Pending or Judge System
+  val isRejectAction = {
+    allOf(Coll(
+      (isPending || isJudgeSystem),
+      OUTPUTS(0).R4[GroupElement].get == proposerPK,
+      OUTPUTS(0).R5[Coll[Byte]].get == bountyId,
+      OUTPUTS(0).R6[Coll[Byte]].get == metadataJson,
+      OUTPUTS(0).R7[SigmaProp].get == bountyCreatorProp,
+      OUTPUTS(0).value == SELF.value,
+      OUTPUTS(0).propositionBytes == SELF.propositionBytes,
+      OUTPUTS(0).R8[Int].get == 2,
+      bountyCreatorProp
+    ))
+  }
+
+  // Creator can approve a proposal from Pending/Rejected or after Judge System
   val isApprovalAction = {
     allOf(Coll(
-      (isPending || isRejected),
+      (isPending || isRejected || isJudgeSystem),
       OUTPUTS(0).R4[GroupElement].get == proposerPK,
       OUTPUTS(0).R5[Coll[Byte]].get == bountyId,
       OUTPUTS(0).R6[Coll[Byte]].get == metadataJson,
@@ -73,7 +106,9 @@
 
   val actions = anyOf(Coll(
     isDisputeAction,
+    isEscalateToJudgeSystemAction,
     isMaintenanceAction,
+    isRejectAction,
     isApprovalAction
   ))
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -8,9 +8,10 @@ export default {
       useESM: true,
       tsconfig: 'tsconfig.json'
     }],
-    '^.+\\.es$': '<rootDir>/test/fileMock.cjs'
+    '^.+\\.es$': '<rootDir>/test/rawEsTransform.cjs'
   },
   moduleNameMapper: {
+    '^(.*\\.es)\\?raw$': '$1',
     '^\\$lib/(.*)$': '<rootDir>/src/lib/$1'
   },
   transformIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,23 +30,24 @@
         "tailwind-variants": "^1.0.0"
       },
       "devDependencies": {
-        "@fleet-sdk/core": "^0.8.1",
-        "@sveltejs/adapter-static": "^3.0.8",
-        "@sveltejs/kit": "^2.21.0",
+        "@fleet-sdk/core": "^0.8.5",
+        "@sveltejs/adapter-static": "^3.0.10",
+        "@sveltejs/kit": "^2.47.2",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tsconfig/svelte": "^5.0.4",
         "@types/jest": "^30.0.0",
         "autoprefixer": "^10.4.21",
         "jest": "^30.1.3",
         "postcss": "^8.5.3",
-        "svelte": "^5.28.6",
+        "svelte": "^5.41.1",
         "svelte-check": "^4.1.7",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "tsx": "^4.19.4",
-        "typescript": "^5.9.2",
-        "vite": "^6.3.0"
+        "typescript": "^5.9.3",
+        "vite": "^6.4.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8364,6 +8365,31 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "test:proposal": "NODE_OPTIONS=--experimental-vm-modules jest proposal-contract.test.ts",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test:watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
+    "test:proposal": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js proposal-contract.test.ts",
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",

--- a/src/lib/common/proposal.ts
+++ b/src/lib/common/proposal.ts
@@ -174,6 +174,9 @@ export function parseProposalBox(box: Box<Amount>, index: number): Proposal | nu
                 case 3:
                     status = "disputed";
                     break;
+                case 4:
+                    status = "judge_system";
+                    break;
                 default:
                     status = "pending";
             }

--- a/src/lib/ergo/actions/update_proposal_status.ts
+++ b/src/lib/ergo/actions/update_proposal_status.ts
@@ -39,7 +39,7 @@ function getSerializedValue(register: any): string {
  */
 export async function updateProposalStatus(
     proposalBox: ProposalBox,
-    newStatus: 0 | 3,
+    newStatus: 0 | 1 | 2 | 3 | 4,
     creatorAddress: string
 ): Promise<string | null> {
     if (!ergo) throw new Error("Ergo object is not available");

--- a/src/lib/ergo/platform.ts
+++ b/src/lib/ergo/platform.ts
@@ -22,7 +22,7 @@ declare const ergo: {
   get_current_height(): Promise<number>;
   sign_tx(tx: any): Promise<any>;
   submit_tx(tx: any): Promise<string>;
-};
+} | undefined;
 
 // Type declarations for Ergo globals - Updated to match types.d.ts
 declare global {
@@ -50,6 +50,12 @@ export class ErgoPlatform implements Platform {
   time_per_block = 2 * 60 * 1000; // 2 minutes per block
   last_version: contract_version = "v1_0";
 
+  private getErgoApi(): typeof ergo | undefined {
+    if (typeof ergo !== 'undefined' && ergo) return ergo;
+    if (typeof window !== 'undefined') return (window as any).ergo;
+    return undefined;
+  }
+
   // --- Wallet Connection ---
   async connect(): Promise<void> {
     if (typeof window.ergoConnector !== 'undefined') {
@@ -57,7 +63,13 @@ export class ErgoPlatform implements Platform {
       if (nautilus) {
         if (await nautilus.connect()) {
           console.log('Connected!');
-          address.set(await ergo.get_change_address());
+          const ergoApi = this.getErgoApi();
+          if (!ergoApi) {
+            console.warn('Connected to Nautilus, but ergo API is not available on window');
+            connected.set(false);
+            return;
+          }
+          address.set(await ergoApi.get_change_address());
           network.set((network_id == "mainnet") ? "ergo-mainnet" : "ergo-testnet");
           await this.get_balance();
           connected.set(true);
@@ -74,7 +86,9 @@ export class ErgoPlatform implements Platform {
 
   async get_address(): Promise<string> {
     try {
-      return await ergo.get_change_address();
+      const ergoApi = this.getErgoApi();
+      if (!ergoApi) throw new Error('Ergo API is not available');
+      return await ergoApi.get_change_address();
     } catch (error) {
       console.error("Failed to get current address:", error);
       throw new Error("Unable to get current address");
@@ -83,8 +97,9 @@ export class ErgoPlatform implements Platform {
 
   async get_current_height(): Promise<number> {
     try {
-      // If connected to the Ergo wallet, get the current height directly
-      return await ergo.get_current_height();
+      const ergoApi = this.getErgoApi();
+      if (!ergoApi) throw new Error('Ergo API is not available');
+      return await ergoApi.get_current_height();
     } catch {
       // Fallback to fetching the current height from the Ergo API
       try {
@@ -104,7 +119,12 @@ export class ErgoPlatform implements Platform {
 
   async get_balance(id?: string): Promise<Map<string, number>> {
     const balanceMap = new Map<string, number>();
-    const addr = await ergo.get_change_address();
+    const ergoApi = this.getErgoApi();
+    if (!ergoApi) {
+      throw new Error('Ergo wallet is not available');
+    }
+
+    const addr = await ergoApi.get_change_address();
 
     if (addr) {
       try {
@@ -175,7 +195,7 @@ export class ErgoPlatform implements Platform {
     return await temp_exchange(bounty, token_amount);
   }
 
-  async updateProposalStatus(proposalBox: ProposalBox, newStatus: 0 | 3, creatorAddress: string): Promise<string | null> {
+  async updateProposalStatus(proposalBox: ProposalBox, newStatus: 0 | 1 | 2 | 3 | 4, creatorAddress: string): Promise<string | null> {
     return await updateProposalStatus(proposalBox, newStatus, creatorAddress);
   }
 
@@ -218,14 +238,15 @@ export class ErgoPlatform implements Platform {
 
     return Promise.all(boxesWithParsed.map(async (box) => {
       const r8 = (box.additionalRegisters as any)?.R8;
-      let status: 'pending' | 'approved' | 'rejected' | 'disputed' = 'pending';
+      let status: 'pending' | 'approved' | 'rejected' | 'disputed' | 'judge_system' = 'pending';
       if (r8 && r8.serializedValue) {
         // The value is a hex string of a number, e.g. "0506" for 3.
         // The first byte is the type (05 for Int), the rest is the value.
         const statusVal = parseInt(r8.serializedValue.slice(2), 16);
-        if (statusVal === 3) {
-          status = 'disputed';
-        }
+        if (statusVal === 1) status = 'approved';
+        else if (statusVal === 2) status = 'rejected';
+        else if (statusVal === 3) status = 'disputed';
+        else if (statusVal === 4) status = 'judge_system';
       }
 
       return {

--- a/src/lib/ergo/proposal_contract.ts
+++ b/src/lib/ergo/proposal_contract.ts
@@ -4,8 +4,9 @@ import { blake2b256, sha256, hex } from "@fleet-sdk/crypto";
 import { uint8ArrayToHex } from "./utils";
 import { network_id } from "./envs";
 import proposalV1_0Template from "../../../contracts/proposal_v1_0.es?raw";
+import proposalV1_1Template from "../../../contracts/proposal_v1_1.es?raw";
 
-export type proposal_contract_version = "v1_0";
+export type proposal_contract_version = "v1_0" | "v1_1";
 
 // Return structure
 export interface ProposalContractDetails {
@@ -18,11 +19,18 @@ function generate_proposal_contract_v1_0(): string {
   return proposalV1_0Template;
 }
 
+// ===== Contract Generator for v1_1 ===== //
+function generate_proposal_contract_v1_1(): string {
+  return proposalV1_1Template;
+}
+
 // ===== Version Switcher ===== //
 function handle_proposal_contract_generator(version: proposal_contract_version): () => string {
   switch (version) {
     case "v1_0":
       return generate_proposal_contract_v1_0;
+    case "v1_1":
+      return generate_proposal_contract_v1_1;
     default:
       throw new Error("Invalid proposal contract version");
   }

--- a/src/routes/ProposalManager.svelte
+++ b/src/routes/ProposalManager.svelte
@@ -306,6 +306,8 @@
                                 status = "rejected";
                             } else if (statusValue === "3") {
                                 status = "disputed";
+                            } else if (statusValue === "4") {
+                                status = "judge_system";
                             }
 
                             return {
@@ -660,6 +662,33 @@
         }
     }
 
+    async function handleJudgeSystem(proposalId: string) {
+        const proposal = proposals.find((p) => p.id === proposalId);
+        if (!proposal || !$address) {
+            console.error("Judge system: missing proposal or address");
+            return;
+        }
+
+        isSubmitting = true;
+        errorMessage = null;
+        try {
+            const txId = await platform.updateProposalStatus(
+                proposal.box,
+                4,
+                $address,
+            );
+            if (txId) {
+                transactionId = txId;
+                setTimeout(loadProposals, 5000);
+            }
+        } catch (e) {
+            console.error("Judge system escalation error:", e);
+            errorMessage = (e as Error).message;
+        } finally {
+            isSubmitting = false;
+        }
+    }
+
     // Initialize proposals when component loads
     $: if (bounty) {
         loadProposals();
@@ -809,7 +838,7 @@
 
                     <div class="card-actions">
                         {#if isCurrentUserJudge}
-                            {#if proposal.status === "pending" || proposal.status === "disputed"}
+                            {#if proposal.status === "pending" || proposal.status === "judge_system"}
                                 <button
                                     class="action-btn approve"
                                     on:click={() =>
@@ -824,6 +853,15 @@
                                     disabled={isSubmitting}
                                 >
                                     Reject
+                                </button>
+                            {/if}
+                            {#if proposal.status === "disputed"}
+                                <button
+                                    class="action-btn dispute"
+                                    on:click={() => handleJudgeSystem(proposal.id)}
+                                    disabled={isSubmitting}
+                                >
+                                    Send to Judge System
                                 </button>
                             {/if}
                             {#if proposal.status === "approved"}

--- a/test/fileMock.cjs
+++ b/test/fileMock.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  process() {
+    return {
+      code: 'module.exports = {};' 
+    };
+  },
+};

--- a/test/proposal-contract.test.ts
+++ b/test/proposal-contract.test.ts
@@ -25,7 +25,8 @@ describe('Proposal Contract Tests', () => {
             PENDING: 0,
             APPROVED: 1, 
             REJECTED: 2,
-            DISPUTED: 3
+            DISPUTED: 3,
+            JUDGE_SYSTEM: 4
         };
         
         // Test status transitions for dispute
@@ -39,6 +40,7 @@ describe('Proposal Contract Tests', () => {
         expect(canDisputeFrom).toContain(1); // Can dispute from approved
         expect(canDisputeFrom).toContain(2); // Can dispute from rejected
         expect(canDisputeFrom).not.toContain(3); // Cannot dispute from disputed
+        expect(canDisputeFrom).not.toContain(4); // Cannot dispute from judge system
         
         console.log('Dispute status validation passed');
     });

--- a/test/rawEsTransform.cjs
+++ b/test/rawEsTransform.cjs
@@ -1,0 +1,10 @@
+const fs = require('fs');
+
+module.exports = {
+  process(_src, filename) {
+    const content = fs.readFileSync(filename, 'utf8');
+    return {
+      code: `module.exports = ${JSON.stringify(content)};`
+    };
+  }
+};


### PR DESCRIPTION
Issue
Tests + contract compile were failing on Windows because Jest couldn’t load *.es?raw contract templates correctly (it treated them as non-strings), and the test script used non-Windows env syntax.
Fix
Made Jest scripts Windows-compatible.
Added a Jest transformer + mapper so *.es?raw loads as raw contract source string (so fleet-sdk/compiler can compile it).
Added wallet guards to avoid blank screen when Nautilus/window.ergo isn’t available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Judge System phase for proposal dispute resolution and escalation
  * New "Send to Judge System" button enables escalation of disputed proposals to external judges
  * Added judge system status to proposal lifecycle tracking

* **Improvements**
  * Enhanced Ergo wallet API resilience with improved error handling and connection verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->